### PR TITLE
Add .NET Standard 2.0 target.

### DIFF
--- a/src/Utf8StringInterpolation/ArrayBufferWriter.cs
+++ b/src/Utf8StringInterpolation/ArrayBufferWriter.cs
@@ -1,0 +1,256 @@
+﻿#if NET6_0_OR_GREATER || NETSTANDARD2_1
+
+using System.Runtime.CompilerServices;
+[assembly: TypeForwardedTo(typeof(System.Buffers.ArrayBufferWriter<>))]
+
+#else
+
+using System;
+using System.Diagnostics;
+
+namespace System.Buffers
+{
+	/// <summary>
+	/// Represents a heap-based, array-backed output sink into which <typeparamref name="T"/> data can be written.
+	/// </summary>
+	/// <typeparam name="T"></typeparam>
+	public sealed class ArrayBufferWriter<T> : IBufferWriter<T>
+	{
+		// Copy of Array.MaxLength.
+		// Used by projects targeting .NET Framework.
+		private const int ArrayMaxLength = 0x7FFFFFC7;
+
+		private const int DefaultInitialBufferSize = 256;
+
+		private T[] _buffer;
+		private int _index;
+
+
+		/// <summary>
+		/// Creates an instance of an <see cref="ArrayBufferWriter{T}"/>, in which data can be written to,
+		/// with the default initial capacity.
+		/// </summary>
+		public ArrayBufferWriter()
+		{
+			_buffer = Array.Empty<T>();
+			_index = 0;
+		}
+
+		/// <summary>
+		/// Creates an instance of an <see cref="ArrayBufferWriter{T}"/>, in which data can be written to,
+		/// with an initial capacity specified.
+		/// </summary>
+		/// <param name="initialCapacity">The minimum capacity with which to initialize the underlying buffer.</param>
+		/// <exception cref="ArgumentException">
+		/// Thrown when <paramref name="initialCapacity"/> is not positive (i.e. less than or equal to 0).
+		/// </exception>
+		public ArrayBufferWriter(int initialCapacity)
+		{
+			if (initialCapacity <= 0)
+				throw new ArgumentException(null, nameof(initialCapacity));
+
+			_buffer = new T[initialCapacity];
+			_index = 0;
+		}
+
+		/// <summary>
+		/// Returns the data written to the underlying buffer so far, as a <see cref="ReadOnlyMemory{T}"/>.
+		/// </summary>
+		public ReadOnlyMemory<T> WrittenMemory => _buffer.AsMemory(0, _index);
+
+		/// <summary>
+		/// Returns the data written to the underlying buffer so far, as a <see cref="ReadOnlySpan{T}"/>.
+		/// </summary>
+		public ReadOnlySpan<T> WrittenSpan => _buffer.AsSpan(0, _index);
+
+		/// <summary>
+		/// Returns the amount of data written to the underlying buffer so far.
+		/// </summary>
+		public int WrittenCount => _index;
+
+		/// <summary>
+		/// Returns the total amount of space within the underlying buffer.
+		/// </summary>
+		public int Capacity => _buffer.Length;
+
+		/// <summary>
+		/// Returns the amount of space available that can still be written into without forcing the underlying buffer to grow.
+		/// </summary>
+		public int FreeCapacity => _buffer.Length - _index;
+
+		/// <summary>
+		/// Clears the data written to the underlying buffer.
+		/// </summary>
+		/// <remarks>
+		/// <para>
+		/// You must reset or clear the <see cref="ArrayBufferWriter{T}"/> before trying to re-use it.
+		/// </para>
+		/// <para>
+		/// The <see cref="ResetWrittenCount"/> method is faster since it only sets to zero the writer's index
+		/// while the <see cref="Clear"/> method additionally zeroes the content of the underlying buffer.
+		/// </para>
+		/// </remarks>
+		/// <seealso cref="ResetWrittenCount"/>
+		public void Clear()
+		{
+			Debug.Assert(_buffer.Length >= _index);
+			_buffer.AsSpan(0, _index).Clear();
+			_index = 0;
+		}
+
+		/// <summary>
+		/// Resets the data written to the underlying buffer without zeroing its content.
+		/// </summary>
+		/// <remarks>
+		/// <para>
+		/// You must reset or clear the <see cref="ArrayBufferWriter{T}"/> before trying to re-use it.
+		/// </para>
+		/// <para>
+		/// If you reset the writer using the <see cref="ResetWrittenCount"/> method, the underlying buffer will not be cleared.
+		/// </para>
+		/// </remarks>
+		/// <seealso cref="Clear"/>
+		public void ResetWrittenCount() => _index = 0;
+
+		/// <summary>
+		/// Notifies <see cref="IBufferWriter{T}"/> that <paramref name="count"/> amount of data was written to the output <see cref="Span{T}"/>/<see cref="Memory{T}"/>
+		/// </summary>
+		/// <exception cref="ArgumentException">
+		/// Thrown when <paramref name="count"/> is negative.
+		/// </exception>
+		/// <exception cref="InvalidOperationException">
+		/// Thrown when attempting to advance past the end of the underlying buffer.
+		/// </exception>
+		/// <remarks>
+		/// You must request a new buffer after calling Advance to continue writing more data and cannot write to a previously acquired buffer.
+		/// </remarks>
+		public void Advance(int count)
+		{
+			if (count < 0)
+				throw new ArgumentException(null, nameof(count));
+
+			if (_index > _buffer.Length - count)
+				ThrowInvalidOperationException_AdvancedTooFar(_buffer.Length);
+
+			_index += count;
+		}
+
+		/// <summary>
+		/// Returns a <see cref="Memory{T}"/> to write to that is at least the requested length (specified by <paramref name="sizeHint"/>).
+		/// If no <paramref name="sizeHint"/> is provided (or it's equal to <code>0</code>), some non-empty buffer is returned.
+		/// </summary>
+		/// <exception cref="ArgumentException">
+		/// Thrown when <paramref name="sizeHint"/> is negative.
+		/// </exception>
+		/// <remarks>
+		/// <para>
+		/// This will never return an empty <see cref="Memory{T}"/>.
+		/// </para>
+		/// <para>
+		/// There is no guarantee that successive calls will return the same buffer or the same-sized buffer.
+		/// </para>
+		/// <para>
+		/// You must request a new buffer after calling Advance to continue writing more data and cannot write to a previously acquired buffer.
+		/// </para>
+		/// <para>
+		/// If you reset the writer using the <see cref="ResetWrittenCount"/> method, this method may return a non-cleared <see cref="Memory{T}"/>.
+		/// </para>
+		/// <para>
+		/// If you clear the writer using the <see cref="Clear"/> method, this method will return a <see cref="Memory{T}"/> with its content zeroed.
+		/// </para>
+		/// </remarks>
+		public Memory<T> GetMemory(int sizeHint = 0)
+		{
+			CheckAndResizeBuffer(sizeHint);
+			Debug.Assert(_buffer.Length > _index);
+			return _buffer.AsMemory(_index);
+		}
+
+		/// <summary>
+		/// Returns a <see cref="Span{T}"/> to write to that is at least the requested length (specified by <paramref name="sizeHint"/>).
+		/// If no <paramref name="sizeHint"/> is provided (or it's equal to <code>0</code>), some non-empty buffer is returned.
+		/// </summary>
+		/// <exception cref="ArgumentException">
+		/// Thrown when <paramref name="sizeHint"/> is negative.
+		/// </exception>
+		/// <remarks>
+		/// <para>
+		/// This will never return an empty <see cref="Span{T}"/>.
+		/// </para>
+		/// <para>
+		/// There is no guarantee that successive calls will return the same buffer or the same-sized buffer.
+		/// </para>
+		/// <para>
+		/// You must request a new buffer after calling Advance to continue writing more data and cannot write to a previously acquired buffer.
+		/// </para>
+		/// <para>
+		/// If you reset the writer using the <see cref="ResetWrittenCount"/> method, this method may return a non-cleared <see cref="Span{T}"/>.
+		/// </para>
+		/// <para>
+		/// If you clear the writer using the <see cref="Clear"/> method, this method will return a <see cref="Span{T}"/> with its content zeroed.
+		/// </para>
+		/// </remarks>
+		public Span<T> GetSpan(int sizeHint = 0)
+		{
+			CheckAndResizeBuffer(sizeHint);
+			Debug.Assert(_buffer.Length > _index);
+			return _buffer.AsSpan(_index);
+		}
+
+		private void CheckAndResizeBuffer(int sizeHint)
+		{
+			if (sizeHint < 0)
+				throw new ArgumentException(nameof(sizeHint));
+
+			if (sizeHint == 0)
+			{
+				sizeHint = 1;
+			}
+
+			if (sizeHint > FreeCapacity)
+			{
+				int currentLength = _buffer.Length;
+
+				// Attempt to grow by the larger of the sizeHint and double the current size.
+				int growBy = Math.Max(sizeHint, currentLength);
+
+				if (currentLength == 0)
+				{
+					growBy = Math.Max(growBy, DefaultInitialBufferSize);
+				}
+
+				int newSize = currentLength + growBy;
+
+				if ((uint)newSize > int.MaxValue)
+				{
+					// Attempt to grow to ArrayMaxLength.
+					uint needed = (uint)(currentLength - FreeCapacity + sizeHint);
+					Debug.Assert(needed > currentLength);
+
+					if (needed > ArrayMaxLength)
+					{
+						ThrowOutOfMemoryException(needed);
+					}
+
+					newSize = ArrayMaxLength;
+				}
+
+				Array.Resize(ref _buffer, newSize);
+			}
+
+			Debug.Assert(FreeCapacity > 0 && FreeCapacity >= sizeHint);
+		}
+
+		private static void ThrowInvalidOperationException_AdvancedTooFar(int capacity)
+		{
+			throw new InvalidOperationException();
+		}
+
+		private static void ThrowOutOfMemoryException(uint capacity)
+		{
+			throw new OutOfMemoryException();
+		}
+	}
+}
+
+#endif

--- a/src/Utf8StringInterpolation/Shims.NetStandard2.cs
+++ b/src/Utf8StringInterpolation/Shims.NetStandard2.cs
@@ -1,0 +1,91 @@
+﻿#if NETSTANDARD2_0
+
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace Utf8StringInterpolation
+{
+	internal static partial class Shims
+	{
+		public static string GetString(this Encoding encoding, scoped ReadOnlySpan<byte> bytes)
+		{
+			if (bytes.IsEmpty) return string.Empty;
+
+			unsafe
+			{
+				fixed (byte* pB = &MemoryMarshal.GetReference(bytes))
+				{
+					return encoding.GetString(pB, bytes.Length);
+				}
+			}
+		}
+
+		public static int GetByteCount(this Encoding encoding, scoped ReadOnlySpan<char> chars)
+		{
+			unsafe
+			{
+				fixed (char* charsPtr = &MemoryMarshal.GetReference(chars))
+				{
+					return encoding.GetByteCount(charsPtr, chars.Length);
+				}
+			}
+		}
+
+		public static int GetBytes(this Encoding encoding, scoped ReadOnlySpan<char> chars, scoped Span<byte> bytes)
+		{
+			unsafe
+			{
+				fixed (char* charsPtr = &MemoryMarshal.GetReference(chars))
+				fixed (byte* bytesPtr = &MemoryMarshal.GetReference(bytes))
+				{
+					return encoding.GetBytes(charsPtr, chars.Length, bytesPtr, bytes.Length);
+				}
+			}
+		}
+
+		private static bool TryFormat(this DateTime value, scoped Span<char> destination, out int charsWritten, string? format, IFormatProvider? formatProvider)
+		{
+			string s = value.ToString(format, formatProvider);
+			if (s.Length > destination.Length)
+			{
+				charsWritten = 0;
+				return false;
+			}
+
+			s.AsSpan().CopyTo(destination);
+			charsWritten = s.Length;
+			return true;
+		}
+
+		private static bool TryFormat(this DateTimeOffset value, scoped Span<char> destination, out int charsWritten, string? format, IFormatProvider? formatProvider)
+		{
+			string s = value.ToString(format, formatProvider);
+			if (s.Length > destination.Length)
+			{
+				charsWritten = 0;
+				return false;
+			}
+
+			s.AsSpan().CopyTo(destination);
+			charsWritten = s.Length;
+			return true;
+		}
+
+		private static bool TryFormat(this TimeSpan value, scoped Span<char> destination, out int charsWritten, string? format, IFormatProvider? formatProvider)
+		{
+			string s = value.ToString(format, formatProvider);
+			if (s.Length > destination.Length)
+			{
+				charsWritten = 0;
+				return false;
+			}
+
+			s.AsSpan().CopyTo(destination);
+			charsWritten = s.Length;
+			return true;
+		}
+	}
+}
+
+#endif

--- a/src/Utf8StringInterpolation/Shims.cs
+++ b/src/Utf8StringInterpolation/Shims.cs
@@ -9,7 +9,7 @@ namespace Utf8StringInterpolation
 {
 #if !NET8_0_OR_GREATER
 
-    internal static class Shims
+    internal static partial class Shims
     {
         public static bool TryFormat(this DateTime value, Span<byte> utf8Destination, out int bytesWritten, string? format, IFormatProvider? formatProvider)
         {
@@ -117,37 +117,3 @@ namespace Utf8StringInterpolation
 
 #endif
 }
-
-#if NETSTANDARD2_1
-
-namespace System.Runtime.CompilerServices
-{
-    /// <summary>Indicates the attributed type is to be used as an interpolated string handler.</summary>
-    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, AllowMultiple = false, Inherited = false)]
-    public sealed class InterpolatedStringHandlerAttribute : Attribute
-    {
-        /// <summary>Initializes the <see cref="InterpolatedStringHandlerAttribute"/>.</summary>
-        public InterpolatedStringHandlerAttribute() { }
-    }
-
-    /// <summary>Indicates which arguments to a method involving an interpolated string handler should be passed to that handler.</summary>
-    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
-    public sealed class InterpolatedStringHandlerArgumentAttribute : Attribute
-    {
-        /// <summary>Initializes a new instance of the <see cref="InterpolatedStringHandlerArgumentAttribute"/> class.</summary>
-        /// <param name="argument">The name of the argument that should be passed to the handler.</param>
-        /// <remarks>The empty string may be used as the name of the receiver in an instance method.</remarks>
-        public InterpolatedStringHandlerArgumentAttribute(string argument) => Arguments = new string[] { argument };
-
-        /// <summary>Initializes a new instance of the <see cref="InterpolatedStringHandlerArgumentAttribute"/> class.</summary>
-        /// <param name="arguments">The names of the arguments that should be passed to the handler.</param>
-        /// <remarks>The empty string may be used as the name of the receiver in an instance method.</remarks>
-        public InterpolatedStringHandlerArgumentAttribute(params string[] arguments) => Arguments = arguments;
-
-        /// <summary>Gets the names of the arguments that should be passed to the handler.</summary>
-        /// <remarks>The empty string may be used as the name of the receiver in an instance method.</remarks>
-        public string[] Arguments { get; }
-    }
-}
-
-#endif

--- a/src/Utf8StringInterpolation/Utf8StringInterpolation.csproj
+++ b/src/Utf8StringInterpolation/Utf8StringInterpolation.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.1;net6.0;net8.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0</TargetFrameworks>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<LangVersion>11</LangVersion>
 		<Nullable>enable</Nullable>
@@ -10,6 +10,18 @@
 		<PackageTags>string</PackageTags>
 		<Description>Successor of ZString; UTF8 based zero allocation high-peformance String Interpolation and StringBuilder.</Description>
 	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
+		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="PolySharp" Version="1.7.1" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
+		<PackageReference Include="System.Memory" Version="4.5.5" />
+	</ItemGroup>
 
 	<ItemGroup>
 		<None Include="../../Icon.png" Pack="true" PackagePath="/" />

--- a/src/Utf8StringInterpolation/Utf8StringWriter.cs
+++ b/src/Utf8StringInterpolation/Utf8StringWriter.cs
@@ -1,11 +1,12 @@
 ﻿#pragma warning disable CA2014 // Do not use stackalloc in loops
 
 using System.Buffers;
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Text;
 using Utf8StringInterpolation.Internal;
+
 #if NET6_0_OR_GREATER
+using System.Diagnostics;
 using System.Text.Unicode;
 #endif
 
@@ -173,10 +174,10 @@ public ref partial struct Utf8StringWriter<TBufferWriter>
         // add left whitespace
         if (alignment > 0)
         {
-            var max = GetStringByteCount(value);
+            var max = GetStringByteCount(value.AsSpan());
             var rentArray = ArrayPool<byte>.Shared.Rent(max);
             var buffer = rentArray.AsSpan();
-            var bytesWritten = Encoding.UTF8.GetBytes(value, buffer);
+            var bytesWritten = Encoding.UTF8.GetBytes(value.AsSpan(), buffer);
 
             var space = alignment - bytesWritten;
             if (space > 0)
@@ -194,9 +195,9 @@ public ref partial struct Utf8StringWriter<TBufferWriter>
         else
         {
             // add right whitespace
-            var max = GetStringByteCount(value);
+            var max = GetStringByteCount(value.AsSpan());
             TryGrow(max);
-            var bytesWritten = Encoding.UTF8.GetBytes(value, destination);
+            var bytesWritten = Encoding.UTF8.GetBytes(value.AsSpan(), destination);
             destination = destination.Slice(bytesWritten);
             currentWritten += bytesWritten;
 

--- a/tests/Utf8StringInterpolation.Tests/FormatTest.cs
+++ b/tests/Utf8StringInterpolation.Tests/FormatTest.cs
@@ -1,9 +1,4 @@
-using FluentAssertions;
-using System;
-using System.Buffers;
 using System.Numerics;
-using System.Text;
-using Xunit;
 
 namespace Utf8StringInterpolation.Tests
 {

--- a/tests/Utf8StringInterpolation.Tests/JoinTest.cs
+++ b/tests/Utf8StringInterpolation.Tests/JoinTest.cs
@@ -61,29 +61,29 @@
         public void JoinOverloads3()
         {
             // Utf8String.Join(",", new string[] { }.ToList()).Should().Be(string.Join(',', new string[0]));
-            Utf8String.Join(",", new[] { 1 }.ToList()).Should().Be(string.Join(',', new[] { 1 }));
-            Utf8String.Join(",", new[] { 1, 2 }.ToList()).Should().Be(string.Join(',', new[] { 1, 2 }));
-            Utf8String.Join(",", new[] { 1, 2, 3 }.ToList()).Should().Be(string.Join(',', new[] { 1, 2, 3 }));
+            Utf8String.Join(",", new[] { 1 }.ToList()).Should().Be(Shims.Join(',', new[] { 1 }));
+            Utf8String.Join(",", new[] { 1, 2 }.ToList()).Should().Be(Shims.Join(',', new[] { 1, 2 }));
+            Utf8String.Join(",", new[] { 1, 2, 3 }.ToList()).Should().Be(Shims.Join(',', new[] { 1, 2, 3 }));
 
-            Utf8String.Join(",", new int[] { }).Should().Be(string.Join(',', new string[0]));
-            Utf8String.Join(",", new[] { 1 }).Should().Be(string.Join(',', new[] { 1 }));
-            Utf8String.Join(",", new[] { 1, 2 }).Should().Be(string.Join(',', new[] { 1, 2 }));
-            Utf8String.Join(",", new[] { 1, 2, 3 }).Should().Be(string.Join(',', new[] { 1, 2, 3 }));
+            Utf8String.Join(",", new int[] { }).Should().Be(Shims.Join(',', new string[0]));
+            Utf8String.Join(",", new[] { 1 }).Should().Be(Shims.Join(',', new[] { 1 }));
+            Utf8String.Join(",", new[] { 1, 2 }).Should().Be(Shims.Join(',', new[] { 1, 2 }));
+            Utf8String.Join(",", new[] { 1, 2, 3 }).Should().Be(Shims.Join(',', new[] { 1, 2, 3 }));
 
-            Utf8String.Join(",", new int[] { }).Should().Be(string.Join(',', new string[0]));
-            Utf8String.Join(",", new[] { 1 }).Should().Be(string.Join(',', new[] { 1 }));
-            Utf8String.Join(",", new[] { 1, 2 }).Should().Be(string.Join(',', new[] { 1, 2 }));
-            Utf8String.Join(",", new[] { 1, 2, 3 }).Should().Be(string.Join(',', new[] { 1, 2, 3 }));
+            Utf8String.Join(",", new int[] { }).Should().Be(Shims.Join(',', new string[0]));
+            Utf8String.Join(",", new[] { 1 }).Should().Be(Shims.Join(',', new[] { 1 }));
+            Utf8String.Join(",", new[] { 1, 2 }).Should().Be(Shims.Join(',', new[] { 1, 2 }));
+            Utf8String.Join(",", new[] { 1, 2, 3 }).Should().Be(Shims.Join(',', new[] { 1, 2, 3 }));
 
-            Utf8String.Join(",", new int[] { }).Should().Be(string.Join(',', new string[0]));
-            Utf8String.Join(",", new[] { 1 }).Should().Be(string.Join(',', new[] { 1 }));
-            Utf8String.Join(",", new[] { 1, 2 }).Should().Be(string.Join(',', new[] { 1, 2 }));
-            Utf8String.Join(",", new[] { 1, 2, 3 }).Should().Be(string.Join(',', new[] { 1, 2, 3 }));
+            Utf8String.Join(",", new int[] { }).Should().Be(Shims.Join(',', new string[0]));
+            Utf8String.Join(",", new[] { 1 }).Should().Be(Shims.Join(',', new[] { 1 }));
+            Utf8String.Join(",", new[] { 1, 2 }).Should().Be(Shims.Join(',', new[] { 1, 2 }));
+            Utf8String.Join(",", new[] { 1, 2, 3 }).Should().Be(Shims.Join(',', new[] { 1, 2, 3 }));
 
-            Utf8String.Join(",", new int[] { }).Should().Be(string.Join(',', new string[0]));
-            Utf8String.Join(",", new[] { 1 }).Should().Be(string.Join(',', new[] { 1 }));
-            Utf8String.Join(",", new[] { 1, 2 }).Should().Be(string.Join(',', new[] { 1, 2 }));
-            Utf8String.Join(",", new[] { 1, 2, 3 }).Should().Be(string.Join(',', new[] { 1, 2, 3 }));
+            Utf8String.Join(",", new int[] { }).Should().Be(Shims.Join(',', new string[0]));
+            Utf8String.Join(",", new[] { 1 }).Should().Be(Shims.Join(',', new[] { 1 }));
+            Utf8String.Join(",", new[] { 1, 2 }).Should().Be(Shims.Join(',', new[] { 1, 2 }));
+            Utf8String.Join(",", new[] { 1, 2, 3 }).Should().Be(Shims.Join(',', new[] { 1, 2, 3 }));
         }
 
         [Fact]
@@ -100,7 +100,7 @@
             var b = new string('b', 1000000);
 
             var actrual = Utf8String.Join(",", new string[] { a, b });
-            var expected = string.Join(',', new string[] { a, b });
+            var expected = Shims.Join(',', new string[] { a, b });
             actrual.Should().Be(expected);
         }
 

--- a/tests/Utf8StringInterpolation.Tests/MathF.cs
+++ b/tests/Utf8StringInterpolation.Tests/MathF.cs
@@ -1,0 +1,13 @@
+﻿#if NETFRAMEWORK
+
+using System;
+
+namespace Utf8StringInterpolation.Tests
+{
+	internal static class MathF
+	{
+		public const float PI = 3.14159265f;
+	}
+}
+
+#endif

--- a/tests/Utf8StringInterpolation.Tests/Shims.cs
+++ b/tests/Utf8StringInterpolation.Tests/Shims.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace Utf8StringInterpolation.Tests
+{
+	internal static class Shims
+	{
+#if NETFRAMEWORK
+		public static string Join<T>(char separator, IEnumerable<T> values) => string.Join(separator.ToString(), values);
+#else
+		public static string Join<T>(char separator, IEnumerable<T> values) => string.Join(separator, values);
+#endif
+	}
+}

--- a/tests/Utf8StringInterpolation.Tests/Utf8StringInterpolation.Tests.csproj
+++ b/tests/Utf8StringInterpolation.Tests/Utf8StringInterpolation.Tests.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net5.0;net6.0;net8.0</TargetFrameworks>
+		<TargetFrameworks>net48;net5.0;net6.0;net8.0</TargetFrameworks>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<LangVersion>11.0</LangVersion>


### PR DESCRIPTION
Using [PolySharp](https://github.com/Sergio0694/PolySharp/) and some extra shims, it is fairly simply to support a .NET Standard 2.0 target.

The consuming application will need to explicitly set `<LangVersion>10</LangVersion>` or later to use the library properly.

**NB:** I couldn't run the tests against .NET 8.0, since I'm not using the VS2022 preview. But they ran successfully against .NET Framework 4.8, .NET 5, .NET 6, and .NET 7.