### PR TITLE
Make sure string alignment calculate as char count

### DIFF
--- a/src/Utf8StringInterpolation/Utf8String.AppendFormatted.cs
+++ b/src/Utf8StringInterpolation/Utf8String.AppendFormatted.cs
@@ -1,6 +1,7 @@
 ﻿using System.Buffers;
 using System.Buffers.Text;
 using System.Runtime.CompilerServices;
+using System.Text;
 
 namespace Utf8StringInterpolation;
 

--- a/tests/Utf8StringInterpolation.Tests/FormatTest.cs
+++ b/tests/Utf8StringInterpolation.Tests/FormatTest.cs
@@ -76,5 +76,12 @@ namespace Utf8StringInterpolation.Tests
             Utf8String.Format($"\u30cf\u30fc\u30c8: {"\u2764"}, \u5bb6\u65cf: {"\uD83D\uDC69\u200D\uD83D\uDC69\u200D\uD83D\uDC67\u200D\uD83D\uDC67"}(\u7d75\u6587\u5b57)")
                  .Should().Be($"\u30cf\u30fc\u30c8: {"\u2764"}, \u5bb6\u65cf: {"\uD83D\uDC69\u200D\uD83D\uDC69\u200D\uD83D\uDC67\u200D\uD83D\uDC67"}(\u7d75\u6587\u5b57)");
         }
+
+        [Fact]
+        public void MultibyteStringAlignment()
+        {
+            Utf8String.Format($"abc{"あいう",10}").Should().Be($"abc{"あいう",10}");
+            Utf8String.Format($"def{"えおか",-10}").Should().Be($"def{"えおか",-10}");
+        }
     }
 }


### PR DESCRIPTION
When calculating alignement, it seems that byte count is used, but correct it to character count.