### PR TITLE
Fix polysharp reference

### DIFF
--- a/src/Utf8StringInterpolation/Shims.cs
+++ b/src/Utf8StringInterpolation/Shims.cs
@@ -3,6 +3,57 @@
 using System.Buffers.Text;
 using System.Text;
 
+#if !NET6_0_OR_GREATER
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>
+    /// Indicates the attributed type is to be used as an interpolated string handler.
+    /// </summary>
+    [global::System.AttributeUsage(
+        global::System.AttributeTargets.Class |
+        global::System.AttributeTargets.Struct,
+        AllowMultiple = false, Inherited = false)]
+    [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    internal sealed class InterpolatedStringHandlerAttribute : global::System.Attribute
+    {
+    }
+
+    /// <summary>
+    /// Indicates which arguments to a method involving an interpolated string handler should be passed to that handler.
+    /// </summary>
+    [global::System.AttributeUsage(global::System.AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
+    [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    internal sealed class InterpolatedStringHandlerArgumentAttribute : global::System.Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="global::System.Runtime.CompilerServices.InterpolatedStringHandlerArgumentAttribute"/> class.
+        /// </summary>
+        /// <param name="argument">The name of the argument that should be passed to the handler.</param>
+        /// <remarks><see langword="null"/> may be used as the name of the receiver in an instance method.</remarks>
+        public InterpolatedStringHandlerArgumentAttribute(string argument)
+        {
+            Arguments = new string[] { argument };
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="global::System.Runtime.CompilerServices.InterpolatedStringHandlerArgumentAttribute"/> class.
+        /// </summary>
+        /// <param name="arguments">The names of the arguments that should be passed to the handler.</param>
+        /// <remarks><see langword="null"/> may be used as the name of the receiver in an instance method.</remarks>
+        public InterpolatedStringHandlerArgumentAttribute(params string[] arguments)
+        {
+            Arguments = arguments;
+        }
+
+        /// <summary>
+        /// Gets the names of the arguments that should be passed to the handler.
+        /// </summary>
+        /// <remarks><see langword="null"/> may be used as the name of the receiver in an instance method.</remarks>
+        public string[] Arguments { get; }
+    }    
+}
+#endif
+
 namespace Utf8StringInterpolation
 {
     internal static partial class Shims

--- a/src/Utf8StringInterpolation/Shims.cs
+++ b/src/Utf8StringInterpolation/Shims.cs
@@ -3,57 +3,6 @@
 using System.Buffers.Text;
 using System.Text;
 
-#if !NET6_0_OR_GREATER
-namespace System.Runtime.CompilerServices
-{
-    /// <summary>
-    /// Indicates the attributed type is to be used as an interpolated string handler.
-    /// </summary>
-    [global::System.AttributeUsage(
-        global::System.AttributeTargets.Class |
-        global::System.AttributeTargets.Struct,
-        AllowMultiple = false, Inherited = false)]
-    [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-    internal sealed class InterpolatedStringHandlerAttribute : global::System.Attribute
-    {
-    }
-
-    /// <summary>
-    /// Indicates which arguments to a method involving an interpolated string handler should be passed to that handler.
-    /// </summary>
-    [global::System.AttributeUsage(global::System.AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
-    [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-    internal sealed class InterpolatedStringHandlerArgumentAttribute : global::System.Attribute
-    {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="global::System.Runtime.CompilerServices.InterpolatedStringHandlerArgumentAttribute"/> class.
-        /// </summary>
-        /// <param name="argument">The name of the argument that should be passed to the handler.</param>
-        /// <remarks><see langword="null"/> may be used as the name of the receiver in an instance method.</remarks>
-        public InterpolatedStringHandlerArgumentAttribute(string argument)
-        {
-            Arguments = new string[] { argument };
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="global::System.Runtime.CompilerServices.InterpolatedStringHandlerArgumentAttribute"/> class.
-        /// </summary>
-        /// <param name="arguments">The names of the arguments that should be passed to the handler.</param>
-        /// <remarks><see langword="null"/> may be used as the name of the receiver in an instance method.</remarks>
-        public InterpolatedStringHandlerArgumentAttribute(params string[] arguments)
-        {
-            Arguments = arguments;
-        }
-
-        /// <summary>
-        /// Gets the names of the arguments that should be passed to the handler.
-        /// </summary>
-        /// <remarks><see langword="null"/> may be used as the name of the receiver in an instance method.</remarks>
-        public string[] Arguments { get; }
-    }    
-}
-#endif
-
 namespace Utf8StringInterpolation
 {
     internal static partial class Shims

--- a/src/Utf8StringInterpolation/Utf8StringInterpolation.csproj
+++ b/src/Utf8StringInterpolation/Utf8StringInterpolation.csproj
@@ -36,4 +36,10 @@
 		</Compile>
 	</ItemGroup>
 
+	<ItemGroup>
+	  <PackageReference Include="PolySharp" Version="1.14.0">
+	    <PrivateAssets>all</PrivateAssets>
+	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+	  </PackageReference>
+	</ItemGroup>
 </Project>

--- a/src/Utf8StringInterpolation/Utf8StringInterpolation.csproj
+++ b/src/Utf8StringInterpolation/Utf8StringInterpolation.csproj
@@ -11,10 +11,6 @@
 		<Description>Successor of ZString; UTF8 based zero allocation high-peformance String Interpolation and StringBuilder.</Description>
 	</PropertyGroup>
 
-	<ItemGroup>
-		<PackageReference Include="PolySharp" Version="1.7.1" />
-	</ItemGroup>
-
 	<ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
 		<PackageReference Include="System.Memory" Version="4.5.5" />
 	</ItemGroup>


### PR DESCRIPTION
~~We will support for Unity, so will stop using Polysharp for portability.~~

Polysharp does not expose the dependencies to outside.
The problem was that the current reference was not a PrivateAsset, so I fixed that ><